### PR TITLE
Fix: console input events not being ignored by android

### DIFF
--- a/services/inputflinger/Android.bp
+++ b/services/inputflinger/Android.bp
@@ -33,6 +33,8 @@ cc_defaults {
         "-Wshadow",
         "-Wshadow-field-in-constructor-modified",
         "-Wshadow-uncaptured-local",
+        "-DCONSOLE_MANAGER",
+        "-DANDROID_VT=7",
     ],
     sanitize: {
         misc_undefined: ["bounds"],
@@ -87,8 +89,6 @@ cc_library_shared {
         "libinputflinger_defaults",
     ],
     cflags: [
-        "-DCONSOLE_MANAGER",
-        "-DANDROID_VT=7",
         // TODO(b/23084678): Move inputflinger to its own process and mark it hidden
         //-fvisibility=hidden
     ],


### PR DESCRIPTION
Fixes an issue in which Android receives keyboard/mouse inputs when on an non-Android VT.
When libinputreader is compiled with the cflags the issue is not present as I have tested. 
Currently the cflags are set for libinputflinger only but not for libinputreader so the console management code in inputreader is ignored https://github.com/BlissRoms-x86/frameworks_native/blob/arcadia-x86/services/inputflinger/reader/EventHub.cpp#L1642
Attached below is a video of the issue: 

https://github.com/BlissRoms-x86/frameworks_native/assets/80520774/693a62b4-4656-48e1-b528-f016108a48bc

